### PR TITLE
update div.h to include algorithm

### DIFF
--- a/include/sketch/div.h
+++ b/include/sketch/div.h
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <utility>
 #include <limits>
+#include <algorithm>
 
 #ifdef __AVX2__
 #include <x86intrin.h>


### PR DESCRIPTION
Fixed compile error when running make in hll. std::equal was not declared, therefore included the algorithm library